### PR TITLE
Avoid write operations to ensure enough disk space for data-compaction

### DIFF
--- a/include/leo_object_storage.hrl
+++ b/include/leo_object_storage.hrl
@@ -178,6 +178,7 @@
 -define(ERROR_LOCKED_CONTAINER,         "locked obj-conatainer").
 -define(ERROR_NOT_ALLOWED_ACCESS,       "not allowed access").
 -define(ERROR_COULD_NOT_START_WORKER,   "could NOT start worker processes").
+-define(ERROR_FREESPACE_LT_AVS,   "The disk free space is less than the size of the AVS file").
 
 -define(ERROR_MSG_SLOW_OPERATION, 'slow_operation').
 -define(ERROR_MSG_TIMEOUT,        'timeout').

--- a/test/leo_object_storage_api_tests.erl
+++ b/test/leo_object_storage_api_tests.erl
@@ -641,6 +641,8 @@ suite_test_() ->
                           ]]}.
 
 setup() ->
+    application:start(sasl),
+    application:start(os_mon),
     application:start(crypto),
     Path1 = "./avs1",
     Path2 = "./avs2",
@@ -654,6 +656,8 @@ teardown([Path1, Path2]) ->
     os:cmd("rm -rf " ++ Path1),
     os:cmd("rm -rf " ++ Path2),
     application:stop(crypto),
+    application:stop(os_mon),
+    application:stop(sasl),
     timer:sleep(1000),
     application:stop(leo_object_storage),
     timer:sleep(1000),
@@ -928,6 +932,8 @@ stats_test_() ->
     {timeout, 15,
      [?_test(
          begin
+             application:start(sasl),
+             application:start(os_mon),
              application:start(crypto),
              Path1 = "./avs1",
              Path2 = "./avs2",
@@ -976,6 +982,8 @@ stats_test_() ->
              application:stop(bitcask),
              application:stop(leo_object_storage),
              application:stop(crypto),
+             application:stop(os_mon),
+             application:stop(sasl),
              os:cmd("rm -rf " ++ Path1),
              os:cmd("rm -rf " ++ Path2),
              true end)]}.


### PR DESCRIPTION
This PR has fixed https://github.com/leo-project/leofs/issues/592 by checking the disk usage and rejecting the write requests if the size of the free disk space is less than the size of the AVS file.

**NOTE**: Now PUT/STORE requests can be rejected by checking the disk usage while DELETE requests are always accepted because DELETE requests can consume the almost same amount of disk space in leo_mq even if the request was rejected here.