### PR TITLE
Fix to make the error message readable for #872

### DIFF
--- a/src/leo_object_storage_server.erl
+++ b/src/leo_object_storage_server.erl
@@ -33,6 +33,7 @@
 -behaviour(gen_server).
 
 -include("leo_object_storage.hrl").
+-include_lib("leo_commons/include/leo_commons.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 %% API
@@ -370,7 +371,7 @@ init([ObjServerState]) ->
                     case (Privilege == ?OBJ_PRV_READ_WRITE andalso
                           ?env_enable_diagnosis_log()) of
                         true ->
-                            _ = filelib:ensure_dir(LogFilePath),
+                            _ = leo_file:ensure_dir(LogFilePath),
                             ok = leo_logger_client_base:new(
                                    ?LOG_GROUP_ID_DIAGNOSIS,
                                    DiagnosisLogId,
@@ -897,7 +898,7 @@ delete_1(Key, Object, #obj_server_state{meta_db_id     = MetaDBId,
 -spec(get_raw_path(object, string(), string()) ->
              {ok, string()} | {error, any()}).
 get_raw_path(object, ObjectStorageRootDir, SymLinkPath) ->
-    case filelib:ensure_dir(ObjectStorageRootDir) of
+    case leo_file:ensure_dir(ObjectStorageRootDir) of
         ok ->
             case file:read_link(SymLinkPath) of
                 {ok, FileName} ->
@@ -927,7 +928,7 @@ get_raw_path(object, ObjectStorageRootDir, SymLinkPath) ->
 %% @private
 close_storage(Id, MetaDBId, StateFilePath,
               StorageStats, WriteHandler, ReadHandler, Reason) when is_list(StateFilePath) ->
-    _ = filelib:ensure_dir(StateFilePath),
+    _ = leo_file:ensure_dir(StateFilePath),
     _ = leo_file:file_unconsult(
           StateFilePath,
           [{id, Id},


### PR DESCRIPTION
- Before
```erlang
[E]     storage_0@127.0.0.1     2017-11-02 15:23:33.294359 +0900        1509603813      leo_storage_app:launch_object_storage    292     CRASH REPORT Process <0.49.0> with 0 neighbours exited with reason: no mat
ch of right hand value {error,{{'EXIT',invalid_launch},{child,undefined,leo_object_storage_sup,{leo_object_storage_sup,start_link,[[{8,"/mnt/leofs"}],leo_storage_msg_collector]},permanent,2000,supervisor,[leo_ob
ject_storage_sup]}}} in leo_storage_app:launch_object_storage/1 line 292 in application_master:init/4 line 134
[E]     storage_0@127.0.0.1     2017-11-02 15:23:38.55047 +0900 1509603818      null:null       0       CRASH REPORT Process <0.113.0> with 0 neighbours exited with reason: enoent in gen_server:init_it/6 line 34
9
```
- After
```erlang
[E]     storage_0@127.0.0.1     2017-11-02 15:45:14.167734 +0900        1509605114      leo_storage_app:launch_object_storage   292     CRASH REPORT Process <0.50.0> with 0 neighbours exited with reason: no matc
h of right hand value {error,{{'EXIT',invalid_launch},{child,undefined,leo_object_storage_sup,{leo_object_storage_sup,start_link,[[{8,"/mnt/leofs/avs"}],leo_storage_msg_collector]},permanent,2000,supervisor,[leo
_object_storage_sup]}}} in leo_storage_app:launch_object_storage/1 line 292 in application_master:init/4 line 134
[E]     storage_0@127.0.0.1     2017-11-02 15:45:19.463534 +0900        1509605119      null:null       0       {module,"leo_file"},{function,"ensure_dir/1"},{line,298},{body,{file,"/mnt/leofs/avs/metadata"},{re
sult,eacces}}
```