### PR TITLE
Add leo_object_storage_api:fetch_by_addr_id_and_disk for #983

### DIFF
--- a/include/leo_object_storage.hrl
+++ b/include/leo_object_storage.hrl
@@ -41,6 +41,7 @@
 -define(DEF_NUM_OF_OBJ_STORAGE_READ_PROCS, 3).
 
 %% ETS-Table
+-define(ETS_CONTAINERS_BY_DISK_TABLE, "leo_object_storage_containers_by_disk_").
 -define(ETS_CONTAINERS_TABLE, 'leo_object_storage_containers').
 -define(ETS_INFO_TABLE, 'leo_object_storage_info').
 -define(ETS_TIMEOUT_MSG_TABLE, 'leo_object_storage_timeout_msg').

--- a/test/leo_object_storage_api_tests.erl
+++ b/test/leo_object_storage_api_tests.erl
@@ -921,7 +921,13 @@ fetch_by_addr_id_([Path1, Path2]) ->
                       end
               end,
         {ok, Res} = leo_object_storage_api:fetch_by_addr_id(0, Fun),
-        ?assertEqual(3, length(Res))
+        ?assertEqual(3, length(Res)),
+        {ok, Res1} = leo_object_storage_api:fetch_by_addr_id_and_disk(0, 1, Fun),
+        ?debugVal(Res1),
+        {ok, Res2} = leo_object_storage_api:fetch_by_addr_id_and_disk(0, 2, Fun),
+        ?debugVal(Res2),
+        ?assertEqual(3, length(Res1) + length(Res2)),
+        ok
     after
         application:stop(leo_backend_db),
         application:stop(bitcask),


### PR DESCRIPTION
This is a part of fix for https://github.com/leo-project/leofs/issues/983#issuecomment-369834156.
fetch_by_addr_id_and_disk added in this PR will be used in the upcoming PR for leofs.